### PR TITLE
Fix typo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_store

--- a/papers/casper-basics/casper_basics.tex
+++ b/papers/casper-basics/casper_basics.tex
@@ -64,7 +64,7 @@ We give an introduction to the consensus algorithm details of Casper: the Friend
 \section{Introduction}
 \label{sect:intro}
 
-In the past few years there has been considerable research into ``proof of stake''-based blockchain consensus algorithms. In a proof of stake system, a blockchain grows and agrees on new blocks through a process where anyone who holds coins inside of the system can participate, and the amount of influence that any given coin holder has is proportional to the number of coins (or ``stake'') that they hold. This represents an alternative to proof of work ``mining'', allowing blockchains to operate without the high hardware and electricity costs that proof of work blockhains require.
+In the past few years there has been considerable research into ``proof of stake''-based blockchain consensus algorithms. In a proof of stake system, a blockchain grows and agrees on new blocks through a process where anyone who holds coins inside of the system can participate, and the amount of influence that any given coin holder has is proportional to the number of coins (or ``stake'') that they hold. This represents an alternative to proof of work ``mining'', allowing blockchains to operate without the high hardware and electricity costs that proof of work blockchains require.
 
 There are two major schools of thought in proof of stake algorithm design. The first, \textit{chain-based proof of stake}, tries to closely mimic the mechanics of proof of work, featuring a chain of blocks and an algorithm that ``simulates'' mining by pseudorandomly assigning the right to create new blocks to stakeholders. This includes Peercoin\cite{king2012ppcoin}, Blackcoin\cite{vasin2014blackcoin} and Iddo Bentov's work\cite{bentov2016pos}.
 


### PR DESCRIPTION
Fix minor typo.
`blockhains` -> `blockchains`