### PR TITLE
Removed journal field for paxos

### DIFF
--- a/papers/CasperTFG/ethereum.bib
+++ b/papers/CasperTFG/ethereum.bib
@@ -17,7 +17,6 @@
 @misc{paxos,
   title={Paxos Made Moderately Complex},
   url={http://paxos.systems/},
-  journal={Paxos Made Moderately Complex}
 }
 
 @article{lamport_1998,


### PR DESCRIPTION
Which also had no comma causing the citation to render with ?.