### PR TITLE
Fix typo in clique oracle pseudocode

### DIFF
--- a/papers/CasperTFG/CasperTFG.tex
+++ b/papers/CasperTFG/CasperTFG.tex
@@ -458,7 +458,7 @@ We present the pseudocode for the ``clique oracle'' that uses this result to det
 
     fault\_tolerance = 2*clique\_weight - total\_weight
 
-    \eIf{fault\_tolerance + initial\_fault\_weight $>$ $t$}
+    \eIf{fault\_tolerance - initial\_fault\_weight $>$ $t$}
     {
       \Return{True}
     }{


### PR DESCRIPTION
@birchmd originally caught this as a mistake reviewing one of my PRs. Having an initial fault weight makes it harder to be safe.

@vladzamfir 