### PR TITLE
Add License and README file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2018 Vitalik Buterin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Research
+
+This repository is used mainly for code related to specific research questions, mostly written by @vbuterin. It is not meant as a general research repository for academic papers.
+
+An exception to this is the `papers` folder, which contains the LaTeX files for various academic papers.
+
+## Contribute
+
+While contributions are welcome, maintaining this repository is not an active priority. The code in this repository is offered as is, without active support.
+
+If you find spelling errors or have suggestions or comments, please feel free to open an issue.
+
+## License
+
+[MIT](LICENSE) © 2015-2018 Vitalik Buterin


### PR DESCRIPTION
This adds a basic README. This README should make explicit how this
repository is used, and set expectations around maintenance and support. I
also explained the repository briefly. None of this should be a surprise;
let me know if I can make the wording better!

I also added an MIT license from the `py_ssz` file, copyrighted to Vitalik.

This should close #73 and resolve #1.