### PR TITLE
verkle_trie: Take the field element value for r and t

### DIFF
--- a/verkle_trie/verkle_trie.py
+++ b/verkle_trie/verkle_trie.py
@@ -363,7 +363,7 @@ def make_kzg_multiproof(Cs, fs, indices, ys, display_times=True):
     """
 
     # Step 1: Construct g(X) polynomial in evaluation form
-    r = hash_to_int([hash(C) for C in Cs] + indices + ys)
+    r = hash_to_int([hash(C) for C in Cs] + indices + ys) % MODULUS
 
     log_time_if_eligible("   Hashed to r", 30, display_times)
 
@@ -384,7 +384,7 @@ def make_kzg_multiproof(Cs, fs, indices, ys, display_times=True):
 
     # Step 2: Compute f in evaluation form
     
-    t = hash_to_int([r, D])
+    t = hash_to_int([r, D]) % MODULUS
     
     h = [0 for i in range(WIDTH)]
     power_of_r = 1


### PR DESCRIPTION
From reading the spec, I understand `r` and `t` to be field elements and not arbitrary-length integers. The python reference, however, will directly hash as an integer, even if it is greater than `MODULUS`.

I believe that `r` and `t` should be taken as field elements, since it consumes less memory to discard the full hash as soon as a field element has been generated from it, instead of having to keep two copies around. Also, I believe this approach would simplify the semantics.