### PR TITLE
optimize zpoly()

### DIFF
--- a/verkle_trie_eip/poly_utils.py
+++ b/verkle_trie_eip/poly_utils.py
@@ -197,12 +197,12 @@ class PrimeField():
 
     # Build a polynomial that returns 0 at all specified xs
     def zpoly(self, xs):
-        root = [1]
-        for x in xs:
-            root.insert(0, 0)
-            for j in range(len(root)-1):
+        root = [0] * len(xs) + [1]
+        for i, x in enumerate(xs):
+            for j in range(len(xs) - i - 1, len(xs)):
                 root[j] -= root[j+1] * x
-        return [x % self.MODULUS for x in root]
+                root[j] = root[j] % self.MODULUS
+        return root
     
     # Given p+1 y values and x values with no errors, recovers the original
     # p+1 degree polynomial.


### PR DESCRIPTION
Original zplot() is slow for a large number of `xs` because of `root.insert(0,0)`.  This optimization preallocates `root` so the total cost is O(n) (instead of O(n^2))

Pref numbers (len(xs) = 128))
- before: 13.77s
- after: 0.239s