### PR TITLE
RS recovery with optimized zpoly on danksharding

### DIFF
--- a/mimc_stark/recovery.py
+++ b/mimc_stark/recovery.py
@@ -61,12 +61,13 @@ def zpoly(positions, modulus, root_of_unity):
         rootz.append((rootz[-1] * root_of_unity) % modulus)
     return _zpoly(positions, modulus, rootz[:-1])
 
-def erasure_code_recover(vals, modulus, root_of_unity):
+def erasure_code_recover(vals, modulus, root_of_unity, z=None):
     # Generate the polynomial that is zero at the roots of unity
     # corresponding to the indices where vals[i] is None
     import poly_utils
-    z = zpoly([i for i in range(len(vals)) if vals[i] is None],
-              modulus, root_of_unity)
+    if z is None:
+        z = zpoly([i for i in range(len(vals)) if vals[i] is None],
+                modulus, root_of_unity)
     zvals = fft(z, modulus, root_of_unity)
 
     # Pointwise-multiply (vals filling in zero at missing spots) * z


### PR DESCRIPTION
This diff implements an optimized zpoly calculation based on danksharding.  The basic idea is that we could use vanishing polynomial to represent a missing sample (16 data points) so that the complexity size is reduced from 8192 to 512 in O(n log^2(n)).

Performance numbers on Mac Book:
Before: 1.28s
After: 0.60