### PR TITLE
Fixing log2 function in merkle_sum_tree.py

### DIFF
--- a/proof_of_solvency/merkle_sum_tree.py
+++ b/proof_of_solvency/merkle_sum_tree.py
@@ -12,7 +12,12 @@ def hash(x):
     return hashlib.sha256(x).digest()
 
 def log2(x):
-    return len(bin(x)) - 2
+    result = 0
+    while x > 1:
+        x >>= 1
+        result += 1
+    return result
+
 
 def get_next_power_of_2(x):
     return 2 * get_next_power_of_2((x+1)//2) if x > 1 else 1
@@ -62,7 +67,7 @@ def get_proof(tree, index):
 # Verifies a proof (duh)
 def verify_proof(username, salt, balance, index, user_table_size, root, proof):
     leaf = userdata_to_leaf(username, salt, balance)
-    branch_length = log2(get_next_power_of_2(user_table_size)) - 1
+    branch_length = log2(get_next_power_of_2(user_table_size))
     for i in range(branch_length):
         if index & (2**i):
             leaf = combine_tree_nodes(proof[i], leaf)
@@ -89,6 +94,5 @@ def test():
     print("Proof:", proof)
     assert verify_proof(b'Charlie', user_table[2][1], 10, 2, 8, root, proof)
     print("Proof checked")
-
 if __name__ == '__main__':
     test()


### PR DESCRIPTION
This PR fixes the `log2` function in the code. The purpose of this function is to calculate the log base 2 of an integer, but the previous implementation was not correct. It would return an integer that was 1 greater than the actual log base 2 of the input value. For example, when applied to a Merkle tree with 8 elements as in the testing, the function would return 4, but the correct value is 3 (since the height of a binary tree with 8 elements is 3).
This PR fixes the `log2` function so that it correctly calculates the log base 2 of an integer. It also updates the `verify_proof` function to use the correct version of the `log2` function. This ensures that the length of the Merkle proof generated by the code is correct.
