### PR TITLE
`py_plonk`: fix bug in transcript

### DIFF
--- a/py_plonk/prover.py
+++ b/py_plonk/prover.py
@@ -167,7 +167,7 @@ def prove_from_witness(setup, group_order, code, var_assignments):
     print("Generated T1, T2, T3 polynomials")
 
     buf2 = serialize_point(T1_pt)+serialize_point(T2_pt)+serialize_point(T3_pt)
-    zed = binhash_to_f_inner(keccak256(buf))
+    zed = binhash_to_f_inner(keccak256(buf2))
 
     # Sanity check that we've computed T1, T2, T3 correctly
     assert (

--- a/py_plonk/verifier.py
+++ b/py_plonk/verifier.py
@@ -21,7 +21,7 @@ def verify_proof(setup, group_order, vk, proof, public=[], optimized=True):
     alpha = binhash_to_f_inner(keccak256(serialize_point(Z_pt)))
 
     buf2 = serialize_point(T1_pt)+serialize_point(T2_pt)+serialize_point(T3_pt)
-    zed = binhash_to_f_inner(keccak256(buf))
+    zed = binhash_to_f_inner(keccak256(buf2))
 
     buf3 = b''.join([
         serialize_int(x) for x in


### PR DESCRIPTION
`buf` was mistakenly used to derive `zed`; we should use `buf2` instead.