### PR TITLE
fix fri test with permuted merkle tree

### DIFF
--- a/mimc_stark/test.py
+++ b/mimc_stark/test.py
@@ -1,6 +1,7 @@
 from fft import fft
 from mimc_stark import mk_mimc_proof, modulus, mimc, verify_mimc_proof
 from merkle_tree import merkelize, mk_branch, verify_branch, bin_length
+from permuted_tree import merkelize as pmerkelize
 from fri import prove_low_degree, verify_low_degree_proof
 
 def test_merkletree():
@@ -19,17 +20,17 @@ def test_fri():
     evaluations = fft(poly, modulus, root_of_unity)
     proof = prove_low_degree(evaluations, root_of_unity, 4096, modulus)
     print("Approx proof length: %d" % fri_proof_bin_length(proof))
-    assert verify_low_degree_proof(merkelize(evaluations)[1], root_of_unity, proof, 4096, modulus)
+    assert verify_low_degree_proof(pmerkelize(evaluations)[1], root_of_unity, proof, 4096, modulus)
     
     try:
         fakedata = [x if pow(3, i, 4096) > 400 else 39 for x, i in enumerate(evaluations)]
         proof2 = prove_low_degree(fakedata, root_of_unity, 4096, modulus)
-        assert verify_low_degree_proof(merkelize(fakedata)[1], root_of_unity, proof, 4096, modulus)
+        assert verify_low_degree_proof(pmerkelize(fakedata)[1], root_of_unity, proof, 4096, modulus)
         raise Exception("Fake data passed FRI")
     except:
         pass
     try:
-        assert verify_low_degree_proof(merkelize(evaluations)[1], root_of_unity, proof, 2048, modulus)
+        assert verify_low_degree_proof(pmerkelize(evaluations)[1], root_of_unity, proof, 2048, modulus)
         raise Exception("Fake data passed FRI")
     except:
         pass
@@ -50,4 +51,5 @@ def test_stark():
     assert verify_mimc_proof(3, 2**LOGSTEPS, constants, mimc(3, 2**LOGSTEPS, constants), proof)
 
 if __name__ == '__main__':
+    test_fri()
     test_stark()


### PR DESCRIPTION
FRI test failed because the Merkle tree root hash in test.py mismatches the one in fri.py, which uses permuted Merkle tree.  The PR fixes the issue and passes the test.