### PR TITLE
FRI uses barycentric formula to evaluate poly

### DIFF
--- a/mimc_stark/fri.py
+++ b/mimc_stark/fri.py
@@ -35,11 +35,18 @@ def prove_low_degree(values, root_of_unity, maxdeg_plus_1, modulus, exclude_mult
     # We calculate the column by Lagrange-interpolating each row, and not
     # directly from the polynomial, as this is more efficient
     quarter_len = len(xs)//4
-    x_polys = f.multi_interp_4(
-        [[xs[i+quarter_len*j] for j in range(4)] for i in range(quarter_len)],
-        [[values[i+quarter_len*j] for j in range(4)] for i in range(quarter_len)]
-    )
-    column = [f.eval_quartic(p, special_x) for p in x_polys]
+    # Using Barycentric forumla to evaluate the polynomial without interpolation
+    # column = [f.eval_barycentric(special_x,
+    #     [xs[i+quarter_len*j] for j in range(4)],
+    #     [values[i+quarter_len*j] for j in range(4)]) for i in range(quarter_len)]
+    column = f.eval_barycentric_all(special_x, xs, values, 4)
+    # Evaluate the polynomial using Lagrange interpolation
+    # x_polys = f.multi_interp_4(
+    #     [[xs[i+quarter_len*j] for j in range(4)] for i in range(quarter_len)],
+    #     [[values[i+quarter_len*j] for j in range(4)] for i in range(quarter_len)]
+    # )
+    # column1 = [f.eval_quartic(p, special_x) for p in x_polys]
+    # assert column == column1
     m2 = merkelize(column)
 
     # Pseudo-randomly select y indices to sample

--- a/mimc_stark/test.py
+++ b/mimc_stark/test.py
@@ -1,3 +1,5 @@
+import time
+
 from fft import fft
 from mimc_stark import mk_mimc_proof, modulus, mimc, verify_mimc_proof
 from merkle_tree import merkelize, mk_branch, verify_branch, bin_length
@@ -18,8 +20,9 @@ def test_fri():
     poly = list(range(4096))
     root_of_unity = pow(7, (modulus-1)//16384, modulus)
     evaluations = fft(poly, modulus, root_of_unity)
+    start_time = time.time()
     proof = prove_low_degree(evaluations, root_of_unity, 4096, modulus)
-    print("Approx proof length: %d" % fri_proof_bin_length(proof))
+    print("Approx proof length: %d, used time: %.4f" % (fri_proof_bin_length(proof), (time.time() - start_time)))
     assert verify_low_degree_proof(pmerkelize(evaluations)[1], root_of_unity, proof, 4096, modulus)
     
     try:

--- a/mimc_stark/test.py
+++ b/mimc_stark/test.py
@@ -1,6 +1,7 @@
 from fft import fft
 from mimc_stark import mk_mimc_proof, modulus, mimc, verify_mimc_proof
 from merkle_tree import merkelize, mk_branch, verify_branch, bin_length
+from permuted_tree import merkelize as pmerkelize
 from fri import prove_low_degree, verify_low_degree_proof
 
 def test_merkletree():
@@ -19,17 +20,17 @@ def test_fri():
     evaluations = fft(poly, modulus, root_of_unity)
     proof = prove_low_degree(evaluations, root_of_unity, 4096, modulus)
     print("Approx proof length: %d" % fri_proof_bin_length(proof))
-    assert verify_low_degree_proof(merkelize(evaluations)[1], root_of_unity, proof, 4096, modulus)
+    assert verify_low_degree_proof(pmerkelize(evaluations)[1], root_of_unity, proof, 4096, modulus)
     
     try:
         fakedata = [x if pow(3, i, 4096) > 400 else 39 for x, i in enumerate(evaluations)]
         proof2 = prove_low_degree(fakedata, root_of_unity, 4096, modulus)
-        assert verify_low_degree_proof(merkelize(fakedata)[1], root_of_unity, proof, 4096, modulus)
+        assert verify_low_degree_proof(pmerkelize(fakedata)[1], root_of_unity, proof, 4096, modulus)
         raise Exception("Fake data passed FRI")
     except:
         pass
     try:
-        assert verify_low_degree_proof(merkelize(evaluations)[1], root_of_unity, proof, 2048, modulus)
+        assert verify_low_degree_proof(pmerkelize(evaluations)[1], root_of_unity, proof, 2048, modulus)
         raise Exception("Fake data passed FRI")
     except:
         pass
@@ -50,4 +51,5 @@ def test_stark():
     assert verify_mimc_proof(3, 2**LOGSTEPS, constants, mimc(3, 2**LOGSTEPS, constants), proof)
 
 if __name__ == '__main__':
+    test_fri()
     test_stark()


### PR DESCRIPTION
This PR optimizes the polynomial evaluation in FRI using the Barycentric formula (in coset) with linear complexity without Lagrange interpolation.  The performance of generating a proof in python is twice that of the Lagrange one.  Below is the perf number on my machine (MacBook):

Degree = 4096, Values = 16384
Before: 0.2776
After: 0.1437s

Degree = 4096, Values = 65536
Before: 1.0076s
After: 0.5226s

The performance gain may be larger if we reduce g(x, x^n) = f(x) with n = 8 or larger.
