### PR TITLE
Fix the threshold in 3sf-mini

### DIFF
--- a/3sf-mini/consensus.py
+++ b/3sf-mini/consensus.py
@@ -94,7 +94,7 @@ def process_block(state: State, block: Block) -> State:
         count = sum(state.justifications[vote.target])
 
         # If 2/3 voted for the same new valid hash to justify
-        if count == (2 * state.config.num_validators) // 3:
+        if 3 * count > 2 * state.config.num_validators:
             state.latest_justified_hash = vote.target
             state.latest_justified_slot = vote.target_slot
             state.justified_slots[vote.target_slot] = True


### PR DESCRIPTION
I believe that 3sf-mini has a rounding issue:

https://github.com/ethereum/research/blob/d225a6775a9b184b5c1fd6c830cc58a375d9535f/3sf-mini/consensus.py#L96-L97

For instance, if `state.config.num_validators == 4`, then the above condition evaluates to `true` on `count == 2`. This is due to the fact that distributed computing literature often refers to thresholds in rational numbers, e.g., $\frac{2n}{3}$, whereas integer division sometimes gives us a smaller threshold. As a result, if a faulty staker sends different blocks to different peers, the network may get partitioned. I have introduced such a proposer in a [fork](https://github.com/konnov/ethereum-research/blob/4be94eb071c4660928bcebe524d172354be16c0c/3sf-mini/p2p.py#L138-L151). Indeed, it keeps growing two and sometimes three chains. I've also noticed scenarios in the simulations, in which validators were forgetting finalized blocks:

![image](https://github.com/user-attachments/assets/65370088-bd40-4a97-83aa-4dfd45b5ffac)

This PR proposes a fix that avoids integer division:

```py
        if 3 * count > 2 * state.config.num_validators:
```

With this fix in place, the simulation seems to work fine, even in the presence of a faulty proposer.